### PR TITLE
Large Update to Swap Process

### DIFF
--- a/Placement Algorithm v1.2.Rmd
+++ b/Placement Algorithm v1.2.Rmd
@@ -1,6 +1,8 @@
 ```{}
-### Survey changes
-* Prior Relationships should be entered one at a time in separate fields, so they export as separate columns and we avoid comma-separation issues (and make small script changes to reflect this)
+### Added TODO's at various points. Ctrl + F 'TODO' to see what is being developed.
+
+### TODO: Survey changes
+* Prior Relationships should be entered one at a time in separate fields so they export as separate columns and we avoid comma-separation issues (and make small script changes to reflect this)
 * CHI - add survey item about whether ACM attended CPS and which school
 ```
 
@@ -25,15 +27,15 @@ dataset$prevent_roommates[1] <-"Yes"
 dataset$consider_HS_elig[1] <- "No"
 
 # Set Soft  Constraints
-dataset$consider_commutes[1] <- "No"
-dataset$commute_factor = 0
+dataset$consider_commutes[1] <- "Yes"
+dataset$commute_factor = 1
 dataset$age_factor = 0
-dataset$ethnicity_factor = 1
+dataset$ethnicity_factor = 0
 dataset$Edscore_factor = 0
 dataset$Tutoring_factor = 0
 dataset$Spanish_factor = 0
 dataset$Math_factor = 0
-dataset$Gender_factor = 1
+dataset$Gender_factor = 0
 dataset$preserve_ij_factor = 0
 ```
 
@@ -531,7 +533,6 @@ s_curve = function(x, center, width) {
 }
 
 #' Annealing and Swap Function
-# TODO: Spanish requirement target set manually school data input
 # TODO: If Spanish speaker randomly chosen for placement, only consider swaps with other Spanish speakers, unless the chosen ACM is already at a school with a surplus of Spanish speakers, in which case they may be placed anywhere
 run_intermediate_annealing_process = function(starting_placements, school_df, best_placements=starting_placements, number_of_iterations, center_scale, width_scale) {
   
@@ -566,9 +567,9 @@ run_intermediate_annealing_process = function(starting_placements, school_df, be
     cand_plcmts_df <- team_placements_df
     
     # Randomly select ACM to swap
-    swap1 <- sample(plcmts_df$acm_id[is.na(plcmts_df$Manual.Placement)
-                                          |plcmts_df$Manual.Placement==""
-                                          |plcmts_df$Manual.Placement==0], 1)
+    swap1 <- sample(cand_plcmts_df$acm_id[is.na(cand_plcmts_df$Manual.Placement)
+                                          |cand_plcmts_df$Manual.Placement==""
+                                          |cand_plcmts_df$Manual.Placement==0], 1)
     
     cand_plcmts_df <- make_swap(cand_plcmts_df, swap1, elig_plc_schwise_df, elig_plc_acmwise_df)
     
@@ -782,7 +783,6 @@ elig_plc_acmwise_df <- elig_plcmnts_acmwise(team_placements_df, prevent_roommate
 team_placements_df <- initial_valid_placement(team_placements_df, school_df, elig_plc_schwise_df, elig_plc_acmwise_df)
 ```
 
-
 ```{r Run Algorithm}
 start.time <- Sys.time()
 output <- run_intermediate_annealing_process(starting_placements = team_placements_df, school_df = school_targets, best_placements = team_placements_df, number_of_iterations = 2000, center_scale=runif(1, 1e-3, 0.25), width_scale=runif(1, 1e-3, 0.25))
@@ -800,9 +800,10 @@ if(output$best_score < 1000000){
 
 write.table(output$best_placements, file = paste(root_dir, "Output - Team Placements (", gsub(":", ".", Sys.time()), ").csv", sep = ""), sep=",", row.names=FALSE, na = "")
 
-#write.table(trace, file = paste(root_dir, "Output - Trace (", gsub(":", ".", Sys.time()), ").csv", sep = ""), sep=",", row.names=FALSE, na = "")
+write.table(trace, file = paste(root_dir, "Output - Trace (", gsub(":", ".", Sys.time()), ").csv", sep = ""), sep=",", row.names=FALSE, na = "")
 
 View(trace)
+plot(trace[,c('iter', 'score')])
 View(best_placements[best_placements$Manual.Placement == "",])
 mean(best_placements$Commute.Time[best_placements$Commute.Time != 999], na.rm = TRUE)
 mean(best_placements$Commute.Rank, na.rm = TRUE)

--- a/Placement Algorithm v1.2.Rmd
+++ b/Placement Algorithm v1.2.Rmd
@@ -1,10 +1,11 @@
-```{md}
+```{}
 ### Survey changes
-* Prior Relationshoips should be entered one at a time, so they are each contained in their own column
+* Prior Relationships should be entered one at a time in separate fields, so they export as separate columns and we avoid comma-separation issues (and make small script changes to reflect this)
+* CHI - add survey item about whether ACM attended CPS and which school
 ```
 
 ```{r Power BI Inputs}
-rm(list=ls(all=TRUE))
+#rm(list=ls(all=TRUE))
 
 # Initialize
 dataset <- data.frame(FP = 1)
@@ -49,8 +50,13 @@ rename_headers <- function(acm_df){
   acm_df
 }
 
+#' Compares all ACM, Team Leader, and Manager names from acm_df and school_df to ensure all
+#' mentioned roommates and prior relationships match a valid ACM survey respondant name.
+#' Exports "Invalid Roommate and Prior Relationship Names.csv"
+#' TODO: raise error listing unmatched names
+#' TODO: Prior Relationships should be separate columns, update script to merge these columns
+#'       as "Prior.Rship.Names"
 clean_RMs_PrRels <- function(acm_df, school_df){
-  # compares all ACM names from acm_df and Team Leader names from school_df to ensure all mentioned roommates and prior relationships match a valid ACM name
   RM_cols <- names(acm_df %>% select(.,matches("Roommate.Name")))
   PrRel_cols <- names(acm_df %>% select(.,matches("Prior.Rship")))
 
@@ -90,11 +96,11 @@ clean_RMs_PrRels <- function(acm_df, school_df){
 }
 
 #  Encode Variables & Clean Up Input Dataframes
-
-#Before being able to calculate a score, we'll need to encode all of our variables numerically.  For categorical ## variables, we can create a dummy variable for all except one of the categories (this is because the last category can be inferred).
-
-# This function takes the input acm_df and encodes the variables in a way that makes the mathematically tractable.
-
+#' Before being able to calculate a score, we need to encode all of our variables numerically.
+#' For categorical ## variables, we create a dummy variable for all except one of the
+#' categories (this is because the last category can be inferred).
+#' This function takes the input acm_df and encodes the variables in a way that makes them
+#' mathematically tractable.
 encode_acm_df <- function(df){
 
   acm_enc <- select(acm_df, acm_id, Math.Confidence)
@@ -139,10 +145,11 @@ encode_acm_df <- function(df){
   return(acm_enc)
 }
 
-# This function calculates some import counts which I'm going to use a lot when trying to figure out the expected number of ACMs per team per metric.  This function will just be used internally by the school_config function.
-
+#' This function calculates some import counts which we use when trying to 
+#' figure out the expected number of ACMs per team per metric.
+#' This function is used internally by the school_config function.
 corps_demographic_targets <- function(school_df, acm_enc){
-  # Calculate some totals used later in the function
+# Calculate some totals used later in the function
   N <- nrow(acm_enc)
   S <- nrow(school_df)
   
@@ -177,9 +184,8 @@ corps_demographic_targets <- function(school_df, acm_enc){
   distros
 }
 
-# Directly calculates the expected number of ACMs per team for each of the markers.
-# My methodology is to aim for a uniform distribution when it makes sense.
-
+#' Calculates the expected number of ACMs per team for each of the markers.
+#' My methodology is to aim for a uniform distribution when it makes sense.
 school_config <- function(school_df, acm_enc){
   # Precalculate some helpful counts
   corps_demos <- corps_demographic_targets(school_df, acm_enc)
@@ -206,12 +212,13 @@ school_config <- function(school_df, acm_enc){
   return(school_df)
 }
 
-elig_plcmnts_static <- function(team_placements_df, school_df){
-
+#' Calculates each ACM's eligibility to searve at each school based on factors
+#' between each ACM and each school (HS eligibility, TL and IM prior 
+#' relationship / roommate conflicts, manual placements, Spanish speakers)
+elig_plcmnts_schwise <- function(team_placements_df, school_df){
   perm <- merge(team_placements_df, school_df, all.x=TRUE) %>%
      mutate(elig = 1, 
             HS_conf = 0, 
-            tl_conf = 0, 
             pre_TL_conf = 0, 
             pre_IM_conf = 0, 
             spanish_conf = 0, 
@@ -222,33 +229,30 @@ elig_plcmnts_static <- function(team_placements_df, school_df){
   if(consider_HS_elig == "Yes"){
     perm$HS_conf[(perm$Ed_SomeCol != 1) & (perm$Ed_Col != 1) & (perm$days_old < 365*21) & (perm$GradeLevel == "High")] <- 1
   }
-  
-  # TL and Previous Relationship conflict (TLs, IMs check)
-  perm$tl_conf <- mapply(grepl, pattern=perm$`Team Leader`, perm$Roommate.Names)
-  perm$tl_conf[is.na(perm$tl_conf)] <- 0
-  perm$pre_TL_conf <- as.numeric(mapply(grepl, pattern=perm$`Team Leader`, perm$Prior.Rship.Name))
-  perm$pre_TL_conf[is.na(perm$tl_conf)] <- 0
+
+  # TL and IM Previous Relationship conflict (TLs, IMs check)
+  perm$pre_TL_conf <- as.numeric(mapply(grepl, pattern=perm$`Team Leader`, paste(perm$Prior.Rship.Name, perm$Roommate.Names)))
   perm$pre_IM_conf <- as.numeric(mapply(grepl, pattern=perm$`Manager`, perm$Prior.Rship.Name))
-  perm$pre_IM_conf[is.na(perm$pre_IM_conf)] <- 0
 
   # Set Manual Placements conflict to 1 for all schools that are not the manual placement
   perm$MP_conf[!is.na(perm$Manual.Placement) & (perm$School != perm$Manual.Placement)] <- 1
   
-  # Set elig col
-  perm$conf_sum <- rowSums(perm[,c("HS_conf", "tl_conf", "pre_TL_conf", "pre_IM_conf", "MP_conf", "spanish_conf")])
-  perm$elig[perm$conf_sum >= 1] <- 0
+  # Sum conflictts to set eligibility. Eligibility defaults to 1, only need to update to 0 where applicable.
+  perm$sch_conf_sum <- rowSums(perm[,c("HS_conf", "pre_TL_conf", "pre_IM_conf", "MP_conf", "spanish_conf")], na.rm=TRUE)
+  perm$elig[perm$sch_conf_sum >= 1] <- 0
   
   # Set eligibility to 1 for the school equal to the manual placement
   perm$elig[!is.na(perm$Manual.Placement) & (perm$School == perm$Manual.Placement)] <- 1
 
   # Remove placement column because placement will change with each iteration
-  perm <- perm[, !names(perm) %in% c("placement")]
+  perm <- perm[, !(names(perm) %in% c("placement"))]
   
   return(perm)
 }
 
-elig_plcmnts_iter <- function(team_placements_df, prevent_roommates){
-  # calculate all ACMs' eligibility to serve with all other ACMs based on roommates and prior relationships
+#' Calculate each ACM's eligibility to serve with all other ACMs based on 
+#' roommates and prior relationships
+elig_plcmnts_acmwise <- function(team_placements_df, prevent_roommates){
   acm1_df <- team_placements_df[,c("acm_id", "Full.Name", "Roommate.Names", "Prior.Rship.Name")]
   acm2_df <- team_placements_df[,c("acm_id", "Full.Name")]
   names(acm2_df) <- c("acm2_id", "acm2_Full.Name")
@@ -259,7 +263,7 @@ elig_plcmnts_iter <- function(team_placements_df, prevent_roommates){
   } else {acm_compat$rm_conf <- 0}
   
   acm_compat$priorrel_conf <- as.numeric(mapply(grepl, pattern=acm_compat$acm2_Full.Name, acm_compat$Prior.Rship.Name))
-  acm_compat$iter_conf <- rowSums(acm_compat[,c("rm_conf", "priorrel_conf")])
+  acm_compat$acm_conf <- rowSums(acm_compat[,c("rm_conf", "priorrel_conf")])
   acm_compat <- acm_compat[acm_compat$acm_id != acm_compat$acm2_id, ]
   
   # ensure that if ACM1 has conflict with ACM34, ACM34 also has conflict with ACM1
@@ -270,14 +274,15 @@ elig_plcmnts_iter <- function(team_placements_df, prevent_roommates){
   
   acm_compat <- acm_compat %>%
     group_by(key) %>% 
-    mutate(key_sum=sum(iter_conf)) %>%
+    mutate(key_sum=sum(acm_conf)) %>%
     ungroup()
   
-  acm_compat$iter_conf[acm_compat$key_sum > 0] <- 1
+  acm_compat$acm_conf[acm_compat$key_sum > 0] <- 1
   
   return(acm_compat[,cols])
 }
 
+#' Make random (other than manual placement) initial school placements
 initial_placement <- function(acm_enc, school_targets){
   
   team_placements = list()
@@ -327,91 +332,114 @@ initial_placement <- function(acm_enc, school_targets){
   return(team_placements_df)
 }
 
-initial_valid_placement <- function(team_placements_df, school_df, prevent_roommates, ij){
+append_elig_col <- function(team_placements_df, elig_plc_schwise_df, elig_plc_acmwise_df){
+  cols <- names(team_placements_df)
+  team_placements_df$acm_id_sch_id <- paste(team_placements_df$acm_id, team_placements_df$placement, sep="_")
+    
+  # Identify current invalid placments based on school factors, merge in "elig" to team_placements_df on acm_id_school_id
+  team_placements_df <- merge(team_placements_df, elig_plc_schwise_df[, c("acm_id_sch_id", "sch_conf_sum")], by="acm_id_sch_id", all.x=TRUE)
 
-  schools_to_swap <- c(0, 0)
+  # Identify current invalid placments based on ACM factors, merge placement to acmwise_df, sum conflict column by group(acm_id, placement), then merge that sum back to team_placements_df
+  elig_plc_acmwise_df <- merge(elig_plc_acmwise_df, team_placements_df[,c("acm_id", "placement")], by="acm_id")
+  elig_plc_acmwise_df$acm_id_sch_id <- paste(elig_plc_acmwise_df$acm_id, elig_plc_acmwise_df$placement, sep="_")
+  elig_plc_acmwise_df$acm2_id_sch_id <- paste(elig_plc_acmwise_df$acm2_id, elig_plc_acmwise_df$placement, sep="_")
+  elig_plc_acmwise_df <- elig_plc_acmwise_df %>%
+    filter(acm2_id_sch_id %in% acm_id_sch_id) %>%
+    group_by(acm_id_sch_id) %>%
+    summarise(acm_conf_sum = sum(acm_conf))
   
-  for(x in 1:3000){
-    team_placements_df <- team_placements_df[, !(names(team_placements_df) %in% c("elig"))]
-    
-    team_placements_df$acm_id_sch_id <- paste(team_placements_df$acm_id, team_placements_df$placement, sep="_")
+  team_placements_df <- merge(team_placements_df, elig_plc_acmwise_df[,c("acm_id_sch_id", "acm_conf_sum")], by = "acm_id_sch_id", all.x = TRUE)
 
-    if(prevent_roommates == "Yes"){
-      elig_placements_iter <- elig_plcmnts_iter(team_placements_df, elig_placements, ij)
-
-      # determine if current roommate conflicts exist
-      teams_no_rm_confs <- team_placements_df[!is.na(team_placements_df$Roommate.Names),] %>%
-        group_by(placement) %>%
-        count(Roommate.Names) %>%
-        filter(n<2) %>%
-        mutate(placement_Roommate.Names = paste(placement, Roommate.Names, sep="_"))
-      
-      teams_rm_confs <- team_placements_df[!is.na(team_placements_df$Roommate.Names),] %>%
-        group_by(placement) %>%
-        count(Roommate.Names) %>%
-        filter(n>1)
-      
-      # Up to this point ACMs with roommates are labeled ineligible if they are the only roommate at their current school. Want to correct rm_conf to 0.
-      elig_placements_iter$sch_id_Roommate.Names <- paste(elig_placements_iter$sch_id, elig_placements_iter$Roommate.Names, sep="_")
-      elig_placements_iter$rm_conf[(elig_placements_iter$sch_id_Roommate.Names %in% teams_no_rm_confs$placement_Roommate.Names) & 
-                                     (elig_placements_iter$acm_id_sch_id %in% team_placements_df$acm_id_sch_id)] <- 0
-
-      elig_placements_iter$elig <- (elig_placements_iter$HS_conf + 
-                                      elig_placements_iter$tl_conf + 
-                                      elig_placements_iter$pre_TL_conf +
-                                      elig_placements_iter$pre_IM_conf +
-                                      elig_placements_iter$spanish_conf +
-                                      elig_placements_iter$MP_conf +
-                                      elig_placements_iter$prev_rel_conf +
-                                      elig_placements_iter$rm_conf)
-      # re-calculate elig
-      elig_placements_iter$elig <- ifelse(elig_placements_iter$elig > 0, 0, 1)
-      
-      elig_placements_iter$elig[!is.na(elig_placements_iter$Manual.Placement) & (elig_placements_iter$School == elig_placements_iter$Manual.Placement)] <- 1
-      elig_placements_iter$elig[!is.na(elig_placements_iter$Manual.Placement) & (elig_placements_iter$School != elig_placements_iter$Manual.Placement)] <- 0
-      
-    } else {
-      elig_placements_iter <- elig_placements
-    }
-    
-    team_placements_df <- merge(team_placements_df, elig_placements_iter[,c("acm_id_sch_id", "elig")], by = "acm_id_sch_id", all.x = TRUE)
-    # Useful for bug searching:
-    #if(nrow(teams_rm_confs[!is.na(teams_rm_confs$Roommate.Names),]) > 0){browser()}
-    #View(elig_placements_iter[(elig_placements_iter$acm_id_sch_id %in% team_placements_df$acm_id_sch_id),])
-    
-    if(nrow(team_placements_df[team_placements_df$elig == 0,]) == 0) {
-      team_placements_df <- team_placements_df[, !names(team_placements_df) %in% c("elig", "acm_id_sch_id")]
-      break
-    }
-    
-    acm_row <- team_placements_df[team_placements_df$elig == 0,][1,]
-    
-    schools_to_swap[1] <- acm_row[["placement"]]
+  team_placements_df$elig <- 1 - rowSums(team_placements_df[,c("sch_conf_sum", "acm_conf_sum")], na.rm=TRUE)
+  team_placements_df$elig[team_placements_df$elig < 0 ] <- 0
   
-    swap1 <- acm_row[["acm_id"]]
-    
-    school2_set <- elig_placements_iter$sch_id[(elig_placements_iter$elig==1) &
-                                               (elig_placements_iter$acm_id == swap1) &
-                                               (elig_placements_iter$sch_id != schools_to_swap[1])]
-    if(length(school2_set)==0){next}
-    
-    if(length(unique(school2_set)) != 1) {schools_to_swap[2] <- sample(x = unique(school2_set), 1)} else {schools_to_swap[2] <- unique(school2_set)}
+  # only keep "elig" col from this func
+  return(team_placements_df[, c(cols, "elig")])
+}
 
-    swap2_set <- elig_placements_iter$acm_id[elig_placements_iter$elig==1 & 
-                                               elig_placements_iter$sch_id == schools_to_swap[1] & 
-                                               elig_placements_iter$acm_id %in% team_placements_df$acm_id[team_placements_df$placement == schools_to_swap[2]]]
-    
-    if(length(swap2_set)==0){next}
-    
-    if(length(unique(swap2_set)) != 1) {swap2 <- sample(x = unique(swap2_set), 1)} else {swap2 <- unique(swap2_set)}
-   
-    # Sort by acm_id and reset the index
-    team_placements_df <- team_placements_df[order(team_placements_df$acm_id), ]
-    rownames(team_placements_df) <- 1:nrow(team_placements_df)
-    
-    team_placements_df$placement <- replace(team_placements_df$placement, c(swap1, swap2), team_placements_df$placement[c(swap2, swap1)])
+#' TODO: validly place Spanish speakers such that each Span ACM is at Span-needing school, or if targets are exceeded, ignore targets
+initial_valid_placement <- function(team_placements_df, school_df, elig_plc_schwise_df, elig_plc_acmwise_df){
+  team_placements_df <- append_elig_col(team_placements_df, elig_plc_schwise_df, elig_plc_acmwise_df)
+  n_inelig <- nrow(team_placements_df[team_placements_df$elig == 0,])
+  
+  while (n_inelig > 0){
+    # Choose one invalid ACM to swap
+    swap1 <- sample(team_placements_df$acm_id[team_placements_df$elig == 0], 1)
+    # drop "elig" column
+    team_placements_df <- team_placements_df[, !(names(team_placements_df) %in% "elig")]
+    # make swap
+    team_placements_df <- make_swap(team_placements_df, swap1, elig_plc_schwise_df, elig_plc_acmwise_df)
+    # recalc "elig" column
+    team_placements_df <- append_elig_col(team_placements_df, elig_plc_schwise_df, elig_plc_acmwise_df)
+    n_inelig <- nrow(team_placements_df[team_placements_df$elig == 0,])
   }
-  return(team_placements_df)
+  # drop "elig" column
+  return(team_placements_df[, !(names(team_placements_df) %in% "elig")])
+}
+
+make_swap <- function(plcmts_df, swap1, elig_plc_schwise_df, elig_plc_acmwise_df){
+  
+  plcmts_df_cols <- names(plcmts_df)
+  plcmts_df$acm_id_sch_id <- paste(plcmts_df$acm_id, plcmts_df$placement, sep="_")
+  
+  schools_to_swap <- c(0, 0)
+  schools_to_swap[1] <- plcmts_df$placement[plcmts_df$acm_id==swap1]
+  school1_ids <- plcmts_df$acm_id[plcmts_df$placement == schools_to_swap[1]]
+  
+  # Find schools at which ACM1 is eligible to serve based on school factors
+  school2_set_schwise <- elig_plc_schwise_df$sch_id[(elig_plc_schwise_df$acm_id == swap1)
+                                                    &(elig_plc_schwise_df$sch_conf_sum==0)
+                                                    &(elig_plc_schwise_df$sch_id != schools_to_swap[1])]
+
+  # Within that set of schools, find schools at which ACM1 is eligible to serve based on the other ACMs at those schools
+  elig_plc_acmwise_df <- merge(elig_plc_acmwise_df, plcmts_df[,c("acm_id", "placement")], by="acm_id")
+  
+  school2_set <- elig_plc_acmwise_df %>%
+    filter(acm2_id == swap1 & placement %in% school2_set_schwise) %>%
+    group_by(placement) %>%
+    summarise(acm_conf_sum=sum(acm_conf)) %>%
+    filter(acm_conf_sum == 0) %>%
+    select(placement) %>% .[["placement"]]
+  
+  if(length(school2_set)==0){
+    return(next)
+  } else if (length(unique(school2_set)) > 1){
+    schools_to_swap[2] <- sample(unique(school2_set), 1)
+  } else {
+    schools_to_swap[2] <- unique(school2_set)
+  }
+  
+  school2_ids = plcmts_df$acm_id[plcmts_df$placement == schools_to_swap[2]]
+  # Find ACMs who are eligible to serve at school1 
+  swap2_set_schwise <- elig_plc_schwise_df$acm_id[(elig_plc_schwise_df$sch_id == schools_to_swap[1])
+                                                  &(elig_plc_schwise_df$elig==1)
+                                                  &(elig_plc_schwise_df$acm_id %in% school2_ids)]
+  
+  # Among those ACMs, find ACMs who are eligible to serve with the ACMs at school1
+  swap2_set <- elig_plc_acmwise_df %>%
+    filter(acm_id %in% swap2_set_schwise & acm2_id %in% school1_ids) %>%
+    group_by(acm_id) %>%
+    summarise(acm_conf_sum=sum(acm_conf)) %>%
+    filter(acm_conf_sum == 0) %>%
+    select(acm_id) %>% .[["acm_id"]]
+  
+  if(length(swap2_set)==0){
+    return(next)
+  } else if(length(unique(swap2_set)) != 1){
+    swap2 <- sample(unique(swap2_set), 1)
+  } else {
+    swap2 <- unique(swap2_set)
+  }
+
+  # Sort by acm_id and reset the index
+  plcmts_df <- plcmts_df[order(plcmts_df$acm_id), ]
+  rownames(plcmts_df) <- 1:nrow(plcmts_df)
+  
+  # make the swap
+  plcmts_df$placement <- replace(plcmts_df$placement, c(swap1, swap2), plcmts_df$placement[c(swap2, swap1)])
+  
+  # return with original columns
+  return(plcmts_df[, plcmts_df_cols])
 }
 
 calculate_score <- function(team_placements_df, school_targets, gender_target=gender_g, commute_factor=dataset$commute_factor, age_factor=dataset$age_factor, ethnicity_factor=dataset$ethnicity_factor, Edscore_factor=dataset$Edscore_factor, Tutoring_factor=dataset$Tutoring_factor, Spanish_factor=dataset$Spanish_factor, Math_factor=dataset$Math_factor, Gender_factor=dataset$Gender_factor) {
@@ -493,8 +521,7 @@ calculate_score <- function(team_placements_df, school_targets, gender_target=ge
   return(scores)
 }
 
-# Temperature Function
-
+#' Temperature Function
 current_temperature = function(iter, s_curve_amplitude, s_curve_center, s_curve_width) {
   s_curve_amplitude * s_curve(iter, s_curve_center, s_curve_width)
 }
@@ -502,10 +529,10 @@ current_temperature = function(iter, s_curve_amplitude, s_curve_center, s_curve_
 s_curve = function(x, center, width) {
   1 / (1 + exp((x - center) / width))
 }
-```
 
-```{r Define Anealing and Swap Functions}
-# Annealing and Swap Function
+#' Annealing and Swap Function
+# TODO: Spanish requirement target set manually school data input
+# TODO: If Spanish speaker randomly chosen for placement, only consider swaps with other Spanish speakers, unless the chosen ACM is already at a school with a surplus of Spanish speakers, in which case they may be placed anywhere
 run_intermediate_annealing_process = function(starting_placements, school_df, best_placements=starting_placements, number_of_iterations, center_scale, width_scale) {
   
   team_placements_df <- starting_placements
@@ -530,77 +557,27 @@ run_intermediate_annealing_process = function(starting_placements, school_df, be
                       score=0)
   
   trace[1, 2:11] <- calculate_score(starting_placements, school_df)
-
-  #Pre-calcucate eligibility of all ACMs to all schools
-  elig_placements <- elig_plcmnts_static(team_placements_df, school_df)
-  
-  schools_to_swap <- c(0, 0)
   
   for(i in 1:number_of_iterations) {
     iter = 1 + i
     temp = current_temperature(iter, 3000, number_of_iterations * center_scale, number_of_iterations * width_scale)
     
     # Create a copy of team_placements_df
-    candidate_placements_df <- team_placements_df
+    cand_plcmts_df <- team_placements_df
     
-    candidate_placements_df$acm_id_sch_id <- paste(candidate_placements_df$acm_id, candidate_placements_df$placement, sep="_")
+    # Randomly select ACM to swap
+    swap1 <- sample(plcmts_df$acm_id[is.na(plcmts_df$Manual.Placement)
+                                          |plcmts_df$Manual.Placement==""
+                                          |plcmts_df$Manual.Placement==0], 1)
     
-    # 1-29-18 Chris: this should not be 'if', since it also includes prior relationships, not just roommates
-    if(prevent_roommates == "Yes"){
-      elig_placements_iter <- elig_plcmnts_iter(candidate_placements_df, elig_placements, ij)
-    } else {
-      elig_placements_iter <- elig_placements
-    }
+    cand_plcmts_df <- make_swap(cand_plcmts_df, swap1, elig_plc_schwise_df, elig_plc_acmwise_df)
     
-    candidate_placements_df <- merge(candidate_placements_df, elig_placements_iter[,c("acm_id_sch_id", "elig")], by="acm_id_sch_id", all.x = TRUE)
-    
-    # 1-29-18 Chris Spanish speaker update to be done: 
-    # Set requirement target manually with column in school config file
-    # Randomly place Spanish speakers such that targets are met (throw error if not possible)
-    # When Spanish speaker randomly chosen for placement, only consider swaps with other Spanish speakers, unless the chosen ACM is already at a school with surplus of Spanish speakers, in which case they could be placed anywhere
-    
-    swap1 <- sample( candidate_placements_df$acm_id[is.na(candidate_placements_df$Manual.Placement)], 1)
-    
-    schools_to_swap[1] <- candidate_placements_df$placement[candidate_placements_df$acm_id==swap1]
-
-    school2_set <- elig_placements_iter$sch_id[(elig_placements_iter$elig==1) &
-                                                 (elig_placements_iter$acm_id == swap1) &
-                                                 (elig_placements_iter$sch_id != schools_to_swap[1])]
-    # & school contains at least one valid ACM to choose who is not roommate/prior relationship of ACM1
-    # to find valid placement, subtract the schools your roommates are in
-    
-    if(length(school2_set)==0){
-      candidate_placements_df <- candidate_placements_df[, !names(candidate_placements_df) %in% c("elig", "elig_rms", "acm_id_sch_id")]
-      next}
-    
-    if(length(unique(school2_set)) != 1) {schools_to_swap[2] <- sample(x = unique(school2_set), 1)} else {schools_to_swap[2] <- unique(school2_set)}
-
-    swap2_set <- elig_placements_iter$acm_id[elig_placements_iter$elig==1 & 
-                                               elig_placements_iter$sch_id == schools_to_swap[1] & 
-                                               elig_placements_iter$acm_id %in%
-                                               candidate_placements_df$acm_id[candidate_placements_df$placement == schools_to_swap[2]]]
-    
-    if(length(swap2_set)==0){
-      candidate_placements_df <- candidate_placements_df[, !names(candidate_placements_df) %in% c("elig", "elig_rms", "acm_id_sch_id")]
-      next}
-    
-    if(length(unique(swap2_set)) != 1) {swap2 <- sample(x = unique(swap2_set), 1)} else {swap2 <- unique(swap2_set)}
-
-    # Sort by acm_id and reset the index
-    candidate_placements_df <- candidate_placements_df[order(candidate_placements_df$acm_id), ]
-    rownames(candidate_placements_df) <- 1:nrow(candidate_placements_df)
-    
-    # Swap the team assignment of those 2 ACMs - NOTE this is done by index, and we use acm_id as index
-    candidate_placements_df$placement <- replace(candidate_placements_df$placement, c(swap1, swap2), candidate_placements_df$placement[c(swap2, swap1)])
-     
-    candidate_placements_df <- candidate_placements_df[, !names(candidate_placements_df) %in% c("elig", "elig_rms", "acm_id_sch_id")]
-    
-    candidate_score <- calculate_score(candidate_placements_df, school_df)
+    candidate_score <- calculate_score(cand_plcmts_df, school_df)
 
     if (temp > 0) {
-      ratio = exp((placement_score - candidate_score$aggr_score) / temp)
+      ratio <- exp((placement_score - candidate_score$aggr_score) / temp)
     } else {
-      ratio = as.numeric(candidate_score$aggr_score < placement_score)
+      ratio <- as.numeric(candidate_score$aggr_score < placement_score)
     }
     
     # Used for bug testing
@@ -612,7 +589,7 @@ run_intermediate_annealing_process = function(starting_placements, school_df, be
     # }
     
     if (runif(1) < ratio) {
-      team_placements_df <- candidate_placements_df
+      team_placements_df <- cand_plcmts_df
       placement_score <- candidate_score$aggr_score
       trace[i+1, 2:11] <- candidate_score
 
@@ -729,7 +706,7 @@ run_intermediate_annealing_process = function(starting_placements, school_df, be
 }
 ```
 
-```{r Load In and Prep Data and Run Initial Placement}
+```{r Load In Prep Data Run Initial Placement}
 library(readxl)
 library(dplyr)
 library(tidyr)
@@ -788,19 +765,25 @@ acm_enc <- encode_acm_df(acm_df)
 
 school_targets <- school_config(school_df, acm_enc)
 
+# This seed (1) produces 3 errors to fix
+set.seed(1)
+
 team_placements_df <- initial_placement(acm_enc, school_targets)
 
-elig_placements <- elig_plcmnts_static(team_placements_df, school_df)
-elig_placements_iter <- elig_plcmnts_iter(team_placements_df, prevent_roommates)
+elig_plc_schwise_df <- elig_plcmnts_schwise(team_placements_df, school_df)
+elig_plc_acmwise_df <- elig_plcmnts_acmwise(team_placements_df, prevent_roommates)
 
+#Testing
+# team_placements_df <- append_elig_col(team_placements_df, elig_plc_schwise_df, elig_plc_acmwise_df)
+# n_inelig <- nrow(team_placements_df[team_placements_df$elig == 0,])
+# team_placements_df <- team_placements_df[, !(names(team_placements_df) %in% "elig")]
+# paste(n_inelig)
+
+team_placements_df <- initial_valid_placement(team_placements_df, school_df, elig_plc_schwise_df, elig_plc_acmwise_df)
 ```
 
-```{r}
-# TO DO: fix all instances of previous elig_plcmnts_iter... aka a lot of work :)
-team_placements_df <- initial_valid_placement(team_placements_df, school_df, prevent_roommates=prevent_roommates, ij=ij)
-```
 
-```{r}
+```{r Run Algorithm}
 start.time <- Sys.time()
 output <- run_intermediate_annealing_process(starting_placements = team_placements_df, school_df = school_targets, best_placements = team_placements_df, number_of_iterations = 2000, center_scale=runif(1, 1e-3, 0.25), width_scale=runif(1, 1e-3, 0.25))
 end.time <- Sys.time()

--- a/Placement Algorithm v1.2.Rmd
+++ b/Placement Algorithm v1.2.Rmd
@@ -64,7 +64,7 @@ clean_RMs_PrRels <- function(acm_df, school_df){
   RMs_PrRels_no_match <- Uniq_RMs_PrRels_df[!(unlist(Uniq_RMs_PrRels_df ) %in% c(acm_df$Full.Name, school_df$`Team Leader`, school_df$Manager))]
   write.table(RMs_PrRels_no_match, file = paste0(root_dir, "Invalid Roommate and Prior Relationship Names.csv"), sep=",", row.names=FALSE, col.names=FALSE)
   
-  # create lists of roommates
+  # create consisten roommate sets for each roommate
   RMs_df <- acm_df[,names(acm_df) %in% c("acm_id", "Full.Name", "Roommates", RM_cols)]
   RMs_df <- RMs_df[RMs_df$Roommates == 'Yes' | RMs_df$Full.Name %in% unlist(RMs_df[, RM_cols], use.names = FALSE), ]
 
@@ -83,7 +83,8 @@ clean_RMs_PrRels <- function(acm_df, school_df){
     RMs_df$Roommate.Names[RMs_df$Full.Name == x] <- roommates_list
   }
   
-  amd_df <- merge(acm_df, RMs_df[, c("acm_id", "Roommate.Names")], by="acm_id", all.x=TRUE)
+  acm_df <- acm_df[ , !(names(acm_df) %in% RM_cols)]
+  acm_df <- merge(acm_df, RMs_df[ , c("acm_id", "Roommate.Names")], by="acm_id", all.x=TRUE)
   
   return(acm_df)
 }
@@ -128,9 +129,6 @@ encode_acm_df <- function(df){
                                    Race.Ethnicity,
                                    IJ.Placement,
                                    Prior.Rship.Name,
-                                   Prior.Rship.Name1,
-                                   Prior.Rship.Name2,
-                                   Prior.Rship.Name3,
                                    Roommate.Names), by=c("acm_id" = "acm_id")) %>%
                mutate(days_old = as.integer(Sys.Date() - as.Date(as.character(df$Birth.Date), format="%m/%d/%Y"))) %>%
                replace_na(list(Lang_Other = 0, days_old = 0))
@@ -233,62 +231,51 @@ elig_plcmnts_static <- function(team_placements_df, school_df){
   perm$pre_IM_conf <- as.numeric(mapply(grepl, pattern=perm$`Manager`, perm$Prior.Rship.Name))
   perm$pre_IM_conf[is.na(perm$pre_IM_conf)] <- 0
 
-  # Manual Placements
+  # Set Manual Placements conflict to 1 for all schools that are not the manual placement
   perm$MP_conf[!is.na(perm$Manual.Placement) & (perm$School != perm$Manual.Placement)] <- 1
   
   # Set elig col
   perm$conf_sum <- rowSums(perm[,c("HS_conf", "tl_conf", "pre_TL_conf", "pre_IM_conf", "MP_conf", "spanish_conf")])
   perm$elig[perm$conf_sum >= 1] <- 0
   
-  # 1-29-18 Chris: can't quite remember why I added these 2 lines, probably just to be certain that manual placements trump all
+  # Set eligibility to 1 for the school equal to the manual placement
   perm$elig[!is.na(perm$Manual.Placement) & (perm$School == perm$Manual.Placement)] <- 1
-  perm$elig[!is.na(perm$Manual.Placement) & (perm$School != perm$Manual.Placement)] <- 0
-  
+
   # Remove placement column because placement will change with each iteration
   perm <- perm[, !names(perm) %in% c("placement")]
   
   return(perm)
 }
 
-# Update school eligilibity based on roommates and previous relationships
-# Some way to store these calcs as a reference? For each ACM, colums 'AMC1_id_AMC2_id' and 'elig' (1 or 0)
-elig_plcmnts_iter <- function(team_placements_df, elig_placements, ij){
-
-  # updates "elig" column with a 0 where roommate conflicts WOULD exist if the ACM were to be placed at each school
-  inter_counts_df <- team_placements_df %>%
-    group_by(placement) %>%
-    summarise(team.roommates = paste0(unique(Roommate.Names), collapse=""), team.names = paste0(Full.Name, collapse=""))
-  #, IJ.Teams = if(ij == "IJ teams already exist. Prevent IJ teammates from serving on school teams.") paste0(unique(IJ.Placement), collapse="") else 0
-
-  elig_iter_df <- merge(elig_placements, inter_counts_df, by.x="sch_id", by.y="placement", all.x=TRUE)
-
-  # rm_conf = 1 where there is a roommate conflict
-  elig_iter_df$rm_conf[!is.na(elig_iter_df$Roommate.Names)] <- as.numeric(mapply(grepl, pattern=elig_iter_df$Roommate.Names[!is.na(elig_iter_df$Roommate.Names)], elig_iter_df$team.roommates[!is.na(elig_iter_df$Roommate.Names)]))
+elig_plcmnts_iter <- function(team_placements_df, prevent_roommates){
+  # calculate all ACMs' eligibility to serve with all other ACMs based on roommates and prior relationships
+  acm1_df <- team_placements_df[,c("acm_id", "Full.Name", "Roommate.Names", "Prior.Rship.Name")]
+  acm2_df <- team_placements_df[,c("acm_id", "Full.Name")]
+  names(acm2_df) <- c("acm2_id", "acm2_Full.Name")
+  acm_compat <- merge(acm1_df, acm2_df, all.x=TRUE)
   
-  elig_iter_df$rm_conf[is.na(elig_iter_df$rm_conf)] <- 0
+  if (prevent_roommates == "Yes"){
+    acm_compat$rm_conf <- as.numeric(mapply(grepl, pattern=acm_compat$acm2_Full.Name, acm_compat$Roommate.Names))
+  } else {acm_compat$rm_conf <- 0}
   
-  # rm_conf = 1 where there is a prev_rel_conf, for each 'Prior.Rship.Name#' column
-  elig_iter_df$prev_rel_conf[!is.na(elig_iter_df$Prior.Rship.Name1)] <- as.numeric(mapply(grepl, pattern=elig_iter_df$Prior.Rship.Name1[!is.na(elig_iter_df$Prior.Rship.Name1)], elig_iter_df$team.names[!is.na(elig_iter_df$Prior.Rship.Name1)]))
+  acm_compat$priorrel_conf <- as.numeric(mapply(grepl, pattern=acm_compat$acm2_Full.Name, acm_compat$Prior.Rship.Name))
+  acm_compat$iter_conf <- rowSums(acm_compat[,c("rm_conf", "priorrel_conf")])
+  acm_compat <- acm_compat[acm_compat$acm_id != acm_compat$acm2_id, ]
   
-  elig_iter_df$prev_rel_conf[!is.na(elig_iter_df$Prior.Rship.Name2) & elig_iter_df$prev_rel_conf != 1] <- as.numeric(mapply(grepl, pattern=elig_iter_df$Prior.Rship.Name2[!is.na(elig_iter_df$Prior.Rship.Name2) & elig_iter_df$prev_rel_conf != 1], elig_iter_df$team.names[!is.na(elig_iter_df$Prior.Rship.Name2) & elig_iter_df$prev_rel_conf != 1]))
+  # ensure that if ACM1 has conflict with ACM34, ACM34 also has conflict with ACM1
+  cols <- names(acm_compat)
+  acm_compat$larger_id <- pmax(acm_compat$acm_id, acm_compat$acm2_id)
+  acm_compat$smaller_id <- pmin(acm_compat$acm_id, acm_compat$acm2_id)
+  acm_compat$key <- paste(acm_compat$smaller_id, acm_compat$larger_id, sep="_")
   
-  elig_iter_df$prev_rel_conf[is.na(elig_iter_df$prev_rel_conf)] <- 0
+  acm_compat <- acm_compat %>%
+    group_by(key) %>% 
+    mutate(key_sum=sum(iter_conf)) %>%
+    ungroup()
   
-  #if (ij == "IJ teams already exist. Prevent IJ teammates from serving on school teams.") {
-  #  elig_iter_df$ij_conf[!is.na(elig_iter_df$IJ.Placement)] <- mapply(grepl, pa#ttern=elig_iter_df$IJ.Placement[!is.na(elig_iter_df$IJ.Placement)], elig_iter_df$IJ.Teams[!is.na(elig_iter_df$IJ.Placement)])
-  #  
-  #  elig_iter_df$ij_conf[elig_iter_df$IJ.Placement == elig_iter_df$`Team Leader`] <- 1
-  #  
-  #  elig_iter_df$ij_conf[is.na(elig_iter_df$ij_conf)] <- 0
-  #  
-  #  elig_iter_df$elig[elig_iter_df$ij_conf == 1] <- 0
-  #}
-
-  # Only need to convert to zero rather than 1 because all items in elig col were defaulted to 1
-  elig_iter_df$iter_conf_sum <- rowSums(elig_iter_df[,c("prev_rel_conf", "rm_conf")])
-  elig_iter_df$elig[(elig_iter_df$iter_conf_sum >= 1) & is.na(elig_iter_df$Manual.Placement)] <- 0
-
-  return(elig_iter_df)
+  acm_compat$iter_conf[acm_compat$key_sum > 0] <- 1
+  
+  return(acm_compat[,cols])
 }
 
 initial_placement <- function(acm_enc, school_targets){
@@ -341,13 +328,11 @@ initial_placement <- function(acm_enc, school_targets){
 }
 
 initial_valid_placement <- function(team_placements_df, school_df, prevent_roommates, ij){
-  
-  elig_placements <- elig_plcmnts_static(team_placements_df, school_df)
 
   schools_to_swap <- c(0, 0)
   
   for(x in 1:3000){
-    team_placements_df <- team_placements_df[, !names(team_placements_df) %in% c("elig")]
+    team_placements_df <- team_placements_df[, !(names(team_placements_df) %in% c("elig"))]
     
     team_placements_df$acm_id_sch_id <- paste(team_placements_df$acm_id, team_placements_df$placement, sep="_")
 
@@ -798,26 +783,21 @@ acm_df[, ethn_cols][acm_df[, ethn_cols] == ""] <- NA
 acm_df$Race.Ethnicity <- apply(acm_df[, ethn_cols], 1, function(x) toString(na.omit(x)))
 
 acm_df <- clean_RMs_PrRels(acm_df, school_df)
-```
 
-```{r}
-# TO DO: work through encoding function to remove mentions of roommate or prior relationships
 acm_enc <- encode_acm_df(acm_df)
 
 school_targets <- school_config(school_df, acm_enc)
+
 team_placements_df <- initial_placement(acm_enc, school_targets)
 
-team_placements_df <- initial_valid_placement(team_placements_df, school_df, prevent_roommates=prevent_roommates, ij=ij)
+elig_placements <- elig_plcmnts_static(team_placements_df, school_df)
+elig_placements_iter <- elig_plcmnts_iter(team_placements_df, prevent_roommates)
+
 ```
 
-```{r Proof of Concept for Eligibility Calcs during Iterations}
-acm1_df <- merge(team_placements_df[,c("acm_id", "Roommate.Names", "placement")], acm_df[,c("acm_id", "Full.Name")])
-names(acm1_df) <- c("acm1_id", "acm1_Roommate.Names", "placement", "acm1_Full.Name")
-acm2_df <- acm1_df[,c("acm1_id", "acm1_Full.Name")]
-names(acm2_df) <- c("acm2_id", "acm2_Full.Name")
-acm_compat <- merge(acm1_df, acm2_df, all.x=TRUE)
-acm_compat$Incompatible <- as.numeric(mapply(grepl, pattern=acm_compat$acm2_Full.Name, acm_compat$acm1_Roommate.Names))
-acm_compat$Incompatible[acm_compat$acm1_id == acm_compat$acm2_id] <- 0
+```{r}
+# TO DO: fix all instances of previous elig_plcmnts_iter... aka a lot of work :)
+team_placements_df <- initial_valid_placement(team_placements_df, school_df, prevent_roommates=prevent_roommates, ij=ij)
 ```
 
 ```{r}


### PR DESCRIPTION
This update makes large changes to our swapping functions.
- more documentation to explain each function
- make_swap() is separated out as its own function. Referenced in annealing function and initial_valid_placement function
- removed code at the end of the script that was used to assess the quality of placements
- elig_plc_schwise_df() - instead of language around 'static' and 'dynamic' calculations of eligibility, changed to school-wise (eligibility factors between acm and each school), and acm-wise (eligibility factors between acm and each acm),
- elig_plc_acmwise_df - same as above
- append_elig_col() - this function is used in initial_valid_placement() to add a 1 or 0 to each row of placements, signifies validity of placement, used for determining whether and how many invalid placements exist
- tested placements: 650 iterations per minute